### PR TITLE
add proTransfer parameter

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     ],
 
     dependencies: [
-        .package(name: "WalletKitCore", url: "https://github.com/rockwalletcode/wallet-kit-core.git", .exact("5.0.27"))
+        .package(name: "WalletKitCore", url: "https://github.com/rockwalletcode/wallet-kit-core.git", .exact("5.0.28"))
     ],
 
     targets: [

--- a/WalletKit/WKClient.swift
+++ b/WalletKit/WKClient.swift
@@ -187,6 +187,7 @@ public protocol SystemClient {
                             exchangeId: String?,
                             secondFactorCode: String?,
                             secondFactorBackup: String?,
+                            proTransfer: String?,
                             isSweep: Bool?,
                             completion: @escaping (Result<TransactionIdentifier, SystemClientError>) -> Void)
 

--- a/WalletKit/WKSystem.swift
+++ b/WalletKit/WKSystem.swift
@@ -1743,7 +1743,7 @@ extension System {
                             wkClientAnnounceTransfersFailure (cwm, sid, System.makeClientErrorCore (e)) })
                 }},
 
-            funcSubmitTransaction: { (context, cwm, sid, identifier, exchangeId, secondFactorCode, secondFactorBackup, isSweep, transactionBytes, transactionBytesLength) in
+            funcSubmitTransaction: { (context, cwm, sid, identifier, exchangeId, secondFactorCode, secondFactorBackup, proTransfer, isSweep, transactionBytes, transactionBytesLength) in
                 precondition (nil != context  && nil != cwm)
 
                 guard let (_, manager) = System.systemExtract (context, cwm)
@@ -1758,12 +1758,15 @@ extension System {
                 
                 let secondFactorBackupString = secondFactorBackup.map { asUTF8String($0) }
 
+                let proTransferString = proTransfer.map { asUTF8String($0) }
+                
                 manager.client.createTransaction (blockchainId: manager.network.uids,
                                                   transaction: data,
                                                   identifier: identifier.map { asUTF8String($0) },
                                                   exchangeId: exchangeIdString,
                                                   secondFactorCode: secondFactorCodeString,
                                                   secondFactorBackup: secondFactorBackupString,
+                                                  proTransfer: proTransferString,
                                                   isSweep: isSweep) {
                     (res: Result<SystemClient.TransactionIdentifier, SystemClientError>) in
                     defer { wkWalletManagerGive (cwm!) }

--- a/WalletKit/WKTransfer.swift
+++ b/WalletKit/WKTransfer.swift
@@ -44,7 +44,7 @@ public final class Transfer: Equatable {
     /// The unit for display of the transfer fee.
     public let unitForFee: Unit
     
-    /// The exchamgeId returned from the swap EP
+    /// The exchangeId returned from the swap EP
     public var exchangeId: String?
     
     /// A 2FA parameter
@@ -52,6 +52,9 @@ public final class Transfer: Equatable {
     
     /// A 2FA parameter
     public var secondFactorBackup: String?
+    
+    /// Pro transfer parameter
+    public var proTransfer: String?
     
     /// A parameter to distinguish send from sweep
     public var isSweep: Bool?

--- a/WalletKit/WKWallet.swift
+++ b/WalletKit/WKWallet.swift
@@ -211,6 +211,7 @@ public final class Wallet: Equatable {
                                 exchangeId: String? = nil,
                                 secondFactorCode: String? = nil,
                                 secondFactorBackup: String? = nil,
+                                proTransfer: String? = nil,
                                 isSweep: Bool? = false) -> Transfer? {
         if nil != attributes && nil != self.validateTransferAttributes(attributes!) {
             return nil
@@ -228,6 +229,7 @@ public final class Wallet: Equatable {
                                            exchangeId,
                                            secondFactorCode,
                                            secondFactorBackup,
+                                           proTransfer,
                                            isSweep ?? false)
             .map { Transfer (core: $0,
                              wallet: self,
@@ -242,6 +244,7 @@ public final class Wallet: Equatable {
                                 exchangeId: String? = nil,
                                 secondFactorCode: String? = nil,
                                 secondFactorBackup: String? = nil,
+                                proTransfer: String? = nil,
                                 isSweep: Bool? = false) -> Transfer? {
         if nil != attributes && nil != self.validateTransferAttributes(attributes!) {
             return nil
@@ -259,6 +262,7 @@ public final class Wallet: Equatable {
                                            exchangeId,
                                            secondFactorCode,
                                            secondFactorBackup,
+                                           proTransfer,
                                            isSweep ?? false)
             .map { Transfer (core: $0,
                              wallet: self,

--- a/WalletKit/common/WKBlockset.swift
+++ b/WalletKit/common/WKBlockset.swift
@@ -984,6 +984,7 @@ public class BlocksetSystemClient: SystemClient {
                                    exchangeId: String?,
                                    secondFactorCode: String?,
                                    secondFactorBackup: String?,
+                                   proTransfer: String?,
                                    isSweep: Bool?,
                                    completion: @escaping (Result<TransactionIdentifier, SystemClientError>) -> Void) {
         let data            = transaction.base64EncodedString()
@@ -1003,6 +1004,10 @@ public class BlocksetSystemClient: SystemClient {
         
         if let secondFactorBackup = secondFactorBackup {
             json["second_factor_backup"] = secondFactorBackup
+        }
+        
+        if let proTransfer = proTransfer {
+            json["pro_transfer"] = proTransfer
         }
         
         if let isSweep = isSweep {


### PR DESCRIPTION
Added necessary code to send the pro_transfer parameter to the backend. The parameter is optional and can be added when calling self.wallet.createTransfer(... proTransfer: value ...) from the client app.